### PR TITLE
redshiftのthread乱発問題修正

### DIFF
--- a/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
@@ -47,6 +47,10 @@ public class RedshiftOutputPlugin
         @Config("database")
         public String getDatabase();
 
+        @Config("thread_maximum")
+        @ConfigDefault("5")
+        public int getThreadMaximum();
+
         @Config("schema")
         @ConfigDefault("\"public\"")
         public String getSchema();
@@ -201,6 +205,6 @@ public class RedshiftOutputPlugin
         RedshiftPluginTask t = (RedshiftPluginTask) task;
         setAWSCredentialsBackwardCompatibility(t);
         return new RedshiftCopyBatchInsert(getConnector(task, true),
-                getAWSCredentialsProvider(t), t.getS3Bucket(), t.getS3KeyPrefix(), t.getIamUserName(), t.getDeleteS3TempFile(), t.getCopyIamRoleName().orElse(null), t.getCopyAwsAccountId().orElse(null));
+                getAWSCredentialsProvider(t), t.getS3Bucket(), t.getS3KeyPrefix(), t.getIamUserName(), t.getDeleteS3TempFile(), t.getCopyIamRoleName().orElse(null), t.getCopyAwsAccountId().orElse(null), t.getThreadMaximum());
     }
 }

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftCopyBatchInsert.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftCopyBatchInsert.java
@@ -67,7 +67,7 @@ public class RedshiftCopyBatchInsert
 
     public RedshiftCopyBatchInsert(JdbcOutputConnector connector,
             AWSCredentialsProvider credentialsProvider, String s3BucketName, String s3KeyPrefix,
-            String iamReaderUserName, boolean deleteS3TempFile, String copyIamRoleName, String copyAwsAccountId) throws IOException, SQLException
+            String iamReaderUserName, boolean deleteS3TempFile, String copyIamRoleName, String copyAwsAccountId, int threadMaximum) throws IOException, SQLException
     {
         super();
         this.connector = connector;
@@ -80,9 +80,9 @@ public class RedshiftCopyBatchInsert
         this.iamReaderUserName = iamReaderUserName;
         this.deleteS3TempFile = deleteS3TempFile;
         this.credentialsProvider = credentialsProvider;
-        this.s3 = new AmazonS3Client(credentialsProvider);  // TODO options
+        this.s3 = new AmazonS3Client(credentialsProvider);
         this.sts = new AWSSecurityTokenServiceClient(credentialsProvider);  // options
-        this.executorService = Executors.newCachedThreadPool();
+        this.executorService = Executors.newFixedThreadPool(threadMaximum);
         this.uploadAndCopyFutures = new ArrayList<Future<Void>>();
 
         String s3RegionName = null;

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftCopyBatchInsert.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftCopyBatchInsert.java
@@ -80,7 +80,7 @@ public class RedshiftCopyBatchInsert
         this.iamReaderUserName = iamReaderUserName;
         this.deleteS3TempFile = deleteS3TempFile;
         this.credentialsProvider = credentialsProvider;
-        this.s3 = new AmazonS3Client(credentialsProvider);
+        this.s3 = new AmazonS3Client(credentialsProvider);  // TODO options
         this.sts = new AWSSecurityTokenServiceClient(credentialsProvider);  // options
         this.executorService = Executors.newFixedThreadPool(threadMaximum);
         this.uploadAndCopyFutures = new ArrayList<Future<Void>>();


### PR DESCRIPTION
fixes #primenumber-dev/n-transfer-ui#3523

- reason
  - The embulk-output-redshift transfers data by uploading them to S3(called UpoadTask) and then scaning the data from s3 for storing(called CopyTask).
  - Both UploadTask and CopyTask would be submitted into Thread Pool to execute ansynchronously.
  - since batch_size is specified as a relative small value such as 16384(16kb), hence the UploadTask and CopyTask incurred frequently. That results in a high-frequent submission of threads of these tasks while the thread pool just create new thread to execute the tasks as current threads are all occupied.
  - All of those above ends in a situation of `org.embulk.exec.PartialExecutionException: java.lang.RuntimeException: org.postgresql.util.PSQLException: FATAL: Sorry, too many connections. Please slow down and try again later.`
  - <img width="1141" alt="Screen Shot 2021-03-25 at 14 17 17" src="https://user-images.githubusercontent.com/26919024/112422821-d5f10f80-8d74-11eb-8556-d17a5c78f5d5.png">

- how to fix
  - As `newCachedThreadPool` would create new thread for execution if and only if current thread are all occupied, it seems tenable to pass a maximum of thread to `newCachedThreadPool`. However, due to the execution mechanism of embulk is ansync we may have troubles in how to determine the max of it. The most simple way to resolve is just make the maximum of each thread pool as a argument. After some performance test, it seems fine to make the default value of `thread_maximum` as 5.
 
- tests
  - without any improvement. batch_size: 1, file_size: 747kb(10,000 rows)
     the test case ended up in a error called `org.embulk.exec.PartialExecutionException: java.lang.RuntimeException: org.postgresql.util.PSQLException: FATAL: Sorry, too many connections. Please slow down and try again later.`.
    Keep in mind that connections actually are not the real problem. The real one was just that too many thread were created.
    <img width="619" alt="Screen Shot 2021-03-25 at 14 27 47" src="https://user-images.githubusercontent.com/26919024/112423590-4b111480-8d76-11eb-96f9-189f35ec1ee5.png">
  - with code improvement. configurations are same as the case above.
    Nothing have got any troubles. But notice that it cost more time than cachedThreadPool. Also check out the note at the end of this PR pls.
    <img width="620" alt="Screen Shot 2021-03-25 at 15 12 51" src="https://user-images.githubusercontent.com/26919024/112427238-96c6bc80-8d7c-11eb-84cb-cc68c3a41cb5.png">

  - with code improvement. batch_size: 16384(16kb, same with production config), file_size: 836.7MB(1,000,000 rows), thread_maximum: 5(default value)
    Everything went well. Neither connections nor threads had any problems.
    <img width="622" alt="Screen Shot 2021-03-25 at 15 10 50" src="https://user-images.githubusercontent.com/26919024/112427101-654df100-8d7c-11eb-966d-dc95f394d784.png">

- **Note: since the maximum of threads in each thread pool has been fixed as a specified value, it would cost more time to finish the transfer task if the batch_size is extremely tiny with default maximum of 5. Try to set a bigger value such as 20, 50, 100, etc.**