### PR TITLE
Added Azure Synapse Analytics to supported products

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           ruby-version: 2.7
       - name: push gem
-        uses: t3t5u/push-gem-to-gpr-action@v1
+        uses: trocco-io/push-gem-to-gpr-action@v2
         with:
           language: java
           gem-path: "embulk-output-${{ matrix.type }}/build/gems/*.gem"

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,36 @@
+name: Ruby Gem
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      matrix:
+        type:
+          - jdbc
+          - mysql
+          - postgresql
+          - redshift
+          - sqlserver
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: push gem
+        uses: t3t5u/push-gem-to-gpr-action@v1
+        with:
+          language: java
+          gem-path: "embulk-output-${{ matrix.type }}/build/gems/*.gem"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          gradle-subproject: "embulk-output-${{ matrix.type }}"

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id "signing"
     id 'checkstyle'
     id "org.embulk.embulk-plugins" version "0.6.2" apply false
+    id "com.palantir.git-version" version "3.0.0"
 }
 
 allprojects {
@@ -15,11 +16,16 @@ allprojects {
     description = "Inserts or updates records to a table."
 }
 
+ext {
+    troccoVersion = "0.0.1"
+}
+
 subprojects {
     apply plugin: 'java'
     apply plugin: "maven-publish"
     apply plugin: "signing"
     apply plugin: "org.embulk.embulk-plugins"
+    apply plugin: 'com.palantir.git-version'
     //apply plugin: 'jacoco'
 
     repositories {
@@ -106,6 +112,7 @@ subprojects {
         summary = "JDBC output plugin for Embulk"
         homepage = "https://github.com/embulk/embulk-output-jdbc"
         licenses = [ "Apache-2.0" ]
+        archiveVersion = "${project.version}.trocco.${project.troccoVersion}"
 
         into("default_jdbc_driver") {
             from configurations.defaultJdbcDriver

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -470,6 +470,46 @@ public class JdbcOutputConnection
         return sb.toString();
     }
 
+    protected void collectUpdateInsert(List<TableIdentifier> fromTables, JdbcSchema schema, TableIdentifier toTable,
+            MergeConfig mergeConfig, Optional<String> preSql, Optional<String> postSql) throws SQLException
+    {
+        if (fromTables.isEmpty()) {
+            return;
+        }
+
+        Statement stmt = connection.createStatement();
+        try {
+            if (preSql.isPresent()) {
+                execute(stmt, preSql.get());
+            }
+
+            executeUpdate(stmt, buildCollectUpdateSql(fromTables, schema, toTable, mergeConfig));
+            executeUpdate(stmt, buildCollectInsertSql(fromTables, schema, toTable, mergeConfig));
+
+            if (postSql.isPresent()) {
+                execute(stmt, postSql.get());
+            }
+
+            commitIfNecessary(connection);
+        } catch (SQLException ex) {
+            throw safeRollback(connection, ex);
+        } finally {
+            stmt.close();
+        }
+    }
+
+    protected String buildCollectUpdateSql(List<TableIdentifier> fromTables, JdbcSchema schema, TableIdentifier toTable,
+            MergeConfig mergeConfig) throws SQLException
+    {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    protected String buildCollectInsertSql(List<TableIdentifier> fromTables, JdbcSchema schema, TableIdentifier toTable,
+            MergeConfig mergeConfig) throws SQLException
+    {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
     protected void collectMerge(List<TableIdentifier> fromTables, JdbcSchema schema, TableIdentifier toTable, MergeConfig mergeConfig,
             Optional<String> preSql, Optional<String> postSql) throws SQLException
     {

--- a/embulk-output-sqlserver/README.md
+++ b/embulk-output-sqlserver/README.md
@@ -65,6 +65,10 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   * Behavior: Same with `insert` mode excepting that it truncates the target table (with SQL `DELETE FROM`, not `TRUNCATE`) right before the last `INSERT ...` query.
   * Transactional: Yes.
   * Resumable: No.
+* **update_insert**:
+  * Behavior: Same with `merge` mode excepting that it runs separated `UPDATE` and `INSERT` statements instead of `MERGE` statement.
+  * Transactional: Yes.
+  * Resumable: No.
 * **replace**:
   * Behavior: This mode writes rows to an intermediate table first. If all those tasks run correctly, drops the target table and alters the name of the intermediate table into the target table name.
   * Transactional: No. If fails, the target table could be dropped (because SQL Server can't rollback DDL).

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/SQLServerOutputPlugin.java
@@ -147,7 +147,7 @@ public class SQLServerOutputPlugin
         return new Features()
             .setMaxTableNameLength(128)
             .setSupportedModes(Collections.unmodifiableSet(new HashSet<Mode>(Arrays.asList(
-                    Mode.INSERT, Mode.INSERT_DIRECT, Mode.MERGE, Mode.TRUNCATE_INSERT, Mode.REPLACE))))
+                    Mode.INSERT, Mode.INSERT_DIRECT, Mode.MERGE, Mode.TRUNCATE_INSERT, Mode.UPDATE_INSERT, Mode.REPLACE))))
             .setIgnoreMergeKeys(false);
     }
 

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/Product.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/Product.java
@@ -1,0 +1,33 @@
+package org.embulk.output.sqlserver;
+
+import java.util.Locale;
+
+import org.embulk.config.ConfigException;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Product
+{
+    // https://learn.microsoft.com/en-us/sql/sql-server/sql-docs-navigation-guide?view=sql-server-ver16#applies-to
+    SQL_SERVER,
+    AZURE_SYNAPSE_ANALYTICS;
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return name().toLowerCase(Locale.ENGLISH);
+    }
+
+    @JsonCreator
+    public static Product fromString(String value)
+    {
+        for (Product product : Product.values()) {
+            if (product.toString().equals(value)) {
+                return product;
+            }
+        }
+        throw new ConfigException(String.format("Unknown product '%s'.", value));
+    }
+}

--- a/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/SQLServerOutputConnector.java
+++ b/embulk-output-sqlserver/src/main/java/org/embulk/output/sqlserver/SQLServerOutputConnector.java
@@ -22,14 +22,16 @@ public class SQLServerOutputConnector
     private final String url;
     private final Properties properties;
     private final String schemaName;
+    private final Product product;
 
     public SQLServerOutputConnector(String url, Properties properties, String schemaName,
-            Optional<TransactionIsolation> transactionIsolation)
+            Optional<TransactionIsolation> transactionIsolation, Product product)
     {
         super(transactionIsolation);
         this.url = url;
         this.properties = properties;
         this.schemaName = schemaName;
+        this.product = product;
     }
 
     @Override
@@ -59,7 +61,7 @@ public class SQLServerOutputConnector
         }
 
         try {
-            SQLServerOutputConnection con = new SQLServerOutputConnection(c, schemaName);
+            SQLServerOutputConnection con = new SQLServerOutputConnection(c, schemaName, product);
             c = null;
             return con;
 


### PR DESCRIPTION
<details>
<summary>test.jsonl</summary>

```
$ cat test.jsonl
{"test_boolean":true,"test_long":123,"test_double":1.23,"test_string":"abc","test_timestamp":"1999-12-31 23:59:59.000 +0000"}
{"test_boolean":false,"test_long":456,"test_double":4.56,"test_string":"def","test_timestamp":"2000-01-01 00:00:00.000 +0000"}
```

</details>
<details>
<summary>config.yml</summary>

```
$ cat config.yml
in:
  type: file
  path_prefix: test.jsonl
  parser:
    type: jsonl
    columns:
    - {name: test_boolean, type: boolean}
    - {name: test_long, type: long}
    - {name: test_double, type: double}
    - {name: test_string, type: string}
    - {name: test_timestamp, type: timestamp}
out:
  type: sqlserver
  product: azure_synapse_analytics
  host: test-synapse-workspace0.sql.azuresynapse.net
  user: test_user@test-synapse-workspace0
  password: ****************
  database: test_dedicated_sql_pool
  schema: test_schema
  table: test_table
  mode: insert
  merge_keys:
  - test_string
  column_options:
    test_boolean: {type: 'BIT'}
    test_long: {type: 'BIGINT'}
    test_double: {type: 'FLOAT'}
    test_string: {type: 'NVARCHAR(4000)', value_type: pass}
    test_timestamp: {type: 'DATETIMEOFFSET'}
  create_table_option: 'WITH (DISTRIBUTION = HASH([test_string]))'
```

</details>
<details>
<summary>run (mode: insert)</summary>

```
$ embulk run config.yml
2024-03-06 02:16:09.211 +0000: Embulk v0.9.26
2024-03-06 02:16:10.007 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-03-06 02:16:11.267 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-03-06 02:16:11.795 +0000 [INFO] (main): Started Embulk v0.9.26
2024-03-06 02:16:11.878 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-sqlserver (0.10.5.trocco.0.0.1)
2024-03-06 02:16:11.912 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.1)
2024-03-06 02:16:11.921 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'test.jsonl'
2024-03-06 02:16:11.922 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2024-03-06 02:16:11.925 +0000 [INFO] (0001:transaction): Loading files [test.jsonl]
2024-03-06 02:16:11.943 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2024-03-06 02:16:11.964 +0000 [WARN] (0001:transaction): "UTC" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:16:11.975 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:16:12.466 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:16:12.467 +0000 [INFO] (0001:transaction): Using JDBC Driver 7.2.2.0
2024-03-06 02:16:12.467 +0000 [INFO] (0001:transaction): Using insert mode
2024-03-06 02:16:13.174 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118c0634_embulk000" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:16:14.384 +0000 [INFO] (0001:transaction): > 1.21 seconds
2024-03-06 02:16:14.417 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118c0634_embulk001" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:16:15.059 +0000 [INFO] (0001:transaction): > 0.64 seconds
2024-03-06 02:16:15.090 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118c0634_embulk002" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:16:15.757 +0000 [INFO] (0001:transaction): > 0.67 seconds
2024-03-06 02:16:15.788 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118c0634_embulk003" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:16:16.420 +0000 [INFO] (0001:transaction): > 0.63 seconds
2024-03-06 02:16:16.450 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118c0634_embulk004" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:16:17.183 +0000 [INFO] (0001:transaction): > 0.73 seconds
2024-03-06 02:16:17.216 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118c0634_embulk005" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:16:17.934 +0000 [INFO] (0001:transaction): > 0.72 seconds
2024-03-06 02:16:17.969 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118c0634_embulk006" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:16:18.769 +0000 [INFO] (0001:transaction): > 0.80 seconds
2024-03-06 02:16:18.888 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118c0634_embulk007" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:16:19.578 +0000 [INFO] (0001:transaction): > 0.69 seconds
2024-03-06 02:16:20.040 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-03-06 02:16:20.052 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:16:20.052 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:16:20.062 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:16:20.180 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:16:20.180 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118c0634_embulk000" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:16:20.183 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:16:20.183 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:16:20.187 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:16:20.341 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:16:20.341 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118c0634_embulk001" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:16:20.343 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:16:20.343 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:16:20.345 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:16:20.540 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:16:20.540 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118c0634_embulk002" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:16:20.541 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:16:20.541 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:16:20.543 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:16:20.633 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:16:20.633 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118c0634_embulk003" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:16:20.634 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:16:20.634 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:16:20.636 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:16:20.767 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:16:20.767 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118c0634_embulk004" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:16:20.768 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:16:20.768 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:16:20.769 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:16:20.859 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:16:20.859 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118c0634_embulk005" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:16:20.859 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:16:20.859 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:16:20.861 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:16:20.962 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:16:20.962 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118c0634_embulk006" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:16:20.963 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:16:20.963 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:16:20.964 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:16:21.105 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:16:21.105 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118c0634_embulk007" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:16:21.154 +0000 [INFO] (0015:task-0000): Loading 2 rows
2024-03-06 02:16:21.554 +0000 [INFO] (0015:task-0000): > 0.40 seconds (loaded 2 rows in total)
2024-03-06 02:16:21.557 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-03-06 02:16:21.558 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:16:21.666 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:16:21.729 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:16:22.387 +0000 [INFO] (0001:transaction): > 0.66 seconds
2024-03-06 02:16:22.401 +0000 [INFO] (0001:transaction): SQL: INSERT INTO "test_schema"."test_table" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118c0634_embulk000" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118c0634_embulk001" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118c0634_embulk002" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118c0634_embulk003" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118c0634_embulk004" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118c0634_embulk005" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118c0634_embulk006" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118c0634_embulk007"
2024-03-06 02:16:24.817 +0000 [INFO] (0001:transaction): > 2.42 seconds (2 rows)
2024-03-06 02:16:24.848 +0000 [WARN] (0001:transaction): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:16:24.848 +0000 [WARN] (0001:transaction): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:16:24.849 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:16:24.948 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:16:25.037 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118c0634_embulk000"
2024-03-06 02:16:25.262 +0000 [INFO] (0001:transaction): > 0.23 seconds
2024-03-06 02:16:25.357 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118c0634_embulk001"
2024-03-06 02:16:25.592 +0000 [INFO] (0001:transaction): > 0.24 seconds
2024-03-06 02:16:25.679 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118c0634_embulk002"
2024-03-06 02:16:25.904 +0000 [INFO] (0001:transaction): > 0.22 seconds
2024-03-06 02:16:26.001 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118c0634_embulk003"
2024-03-06 02:16:26.241 +0000 [INFO] (0001:transaction): > 0.24 seconds
2024-03-06 02:16:26.331 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118c0634_embulk004"
2024-03-06 02:16:26.539 +0000 [INFO] (0001:transaction): > 0.21 seconds
2024-03-06 02:16:26.625 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118c0634_embulk005"
2024-03-06 02:16:26.832 +0000 [INFO] (0001:transaction): > 0.21 seconds
2024-03-06 02:16:26.928 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118c0634_embulk006"
2024-03-06 02:16:27.139 +0000 [INFO] (0001:transaction): > 0.21 seconds
2024-03-06 02:16:27.230 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118c0634_embulk007"
2024-03-06 02:16:27.462 +0000 [INFO] (0001:transaction): > 0.23 seconds
2024-03-06 02:16:27.462 +0000 [INFO] (main): Committed.
2024-03-06 02:16:27.462 +0000 [INFO] (main): Next config diff: {"in":{"last_path":"test.jsonl"},"out":{}}
```

</details>
<details>
<summary>run (mode: insert_direct)</summary>

```
$ embulk run config.yml
2024-03-06 02:18:17.394 +0000: Embulk v0.9.26
2024-03-06 02:18:18.026 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-03-06 02:18:19.351 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-03-06 02:18:19.835 +0000 [INFO] (main): Started Embulk v0.9.26
2024-03-06 02:18:19.909 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-sqlserver (0.10.5.trocco.0.0.1)
2024-03-06 02:18:19.943 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.1)
2024-03-06 02:18:19.954 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'test.jsonl'
2024-03-06 02:18:19.955 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2024-03-06 02:18:19.957 +0000 [INFO] (0001:transaction): Loading files [test.jsonl]
2024-03-06 02:18:19.977 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2024-03-06 02:18:19.998 +0000 [WARN] (0001:transaction): "UTC" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:18:20.010 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:18:20.585 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:18:20.585 +0000 [INFO] (0001:transaction): Using JDBC Driver 7.2.2.0
2024-03-06 02:18:20.585 +0000 [INFO] (0001:transaction): Using insert_direct mode
2024-03-06 02:18:20.815 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-03-06 02:18:20.827 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:18:20.827 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:18:20.837 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:18:20.949 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:18:20.949 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:18:20.952 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:18:20.952 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:18:20.954 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:18:21.052 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:18:21.053 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:18:21.054 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:18:21.054 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:18:21.056 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:18:21.165 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:18:21.165 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:18:21.166 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:18:21.166 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:18:21.168 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:18:21.373 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:18:21.373 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:18:21.374 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:18:21.374 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:18:21.376 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:18:21.507 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:18:21.507 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:18:21.508 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:18:21.508 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:18:21.510 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:18:21.604 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:18:21.604 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:18:21.605 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:18:21.605 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:18:21.607 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:18:21.718 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:18:21.718 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:18:21.719 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:18:21.719 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:18:21.721 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:18:21.807 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:18:21.807 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:18:21.857 +0000 [INFO] (0015:task-0000): Loading 2 rows
2024-03-06 02:18:22.197 +0000 [INFO] (0015:task-0000): > 0.34 seconds (loaded 2 rows in total)
2024-03-06 02:18:22.199 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-03-06 02:18:22.203 +0000 [WARN] (0001:transaction): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:18:22.203 +0000 [WARN] (0001:transaction): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:18:22.204 +0000 [INFO] (main): Committed.
2024-03-06 02:18:22.204 +0000 [INFO] (main): Next config diff: {"in":{"last_path":"test.jsonl"},"out":{}}
```

</details>
<details>
<summary>run (mode: truncate_insert)</summary>

```
$ embulk run config.yml
2024-03-06 02:18:58.778 +0000: Embulk v0.9.26
2024-03-06 02:18:59.409 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-03-06 02:19:00.715 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-03-06 02:19:01.235 +0000 [INFO] (main): Started Embulk v0.9.26
2024-03-06 02:19:01.303 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-sqlserver (0.10.5.trocco.0.0.1)
2024-03-06 02:19:01.336 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.1)
2024-03-06 02:19:01.345 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'test.jsonl'
2024-03-06 02:19:01.346 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2024-03-06 02:19:01.349 +0000 [INFO] (0001:transaction): Loading files [test.jsonl]
2024-03-06 02:19:01.367 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2024-03-06 02:19:01.387 +0000 [WARN] (0001:transaction): "UTC" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:01.398 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:01.778 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:19:01.778 +0000 [INFO] (0001:transaction): Using JDBC Driver 7.2.2.0
2024-03-06 02:19:01.778 +0000 [INFO] (0001:transaction): Using truncate_insert mode
2024-03-06 02:19:01.995 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118e99d7_embulk000" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:02.728 +0000 [INFO] (0001:transaction): > 0.73 seconds
2024-03-06 02:19:02.762 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118e99d7_embulk001" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:03.536 +0000 [INFO] (0001:transaction): > 0.77 seconds
2024-03-06 02:19:03.567 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118e99d7_embulk002" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:04.197 +0000 [INFO] (0001:transaction): > 0.63 seconds
2024-03-06 02:19:04.228 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118e99d7_embulk003" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:04.865 +0000 [INFO] (0001:transaction): > 0.64 seconds
2024-03-06 02:19:04.897 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118e99d7_embulk004" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:05.587 +0000 [INFO] (0001:transaction): > 0.69 seconds
2024-03-06 02:19:05.618 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118e99d7_embulk005" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:06.292 +0000 [INFO] (0001:transaction): > 0.67 seconds
2024-03-06 02:19:06.322 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118e99d7_embulk006" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:06.982 +0000 [INFO] (0001:transaction): > 0.66 seconds
2024-03-06 02:19:07.013 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118e99d7_embulk007" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:07.709 +0000 [INFO] (0001:transaction): > 0.70 seconds
2024-03-06 02:19:07.742 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-03-06 02:19:07.754 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:07.754 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:07.763 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:07.919 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:07.919 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118e99d7_embulk000" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:07.922 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:07.922 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:07.925 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:08.028 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:08.028 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118e99d7_embulk001" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:08.029 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:08.029 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:08.032 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:08.139 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:08.139 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118e99d7_embulk002" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:08.140 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:08.140 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:08.142 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:08.252 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:08.252 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118e99d7_embulk003" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:08.253 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:08.253 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:08.255 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:08.424 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:08.424 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118e99d7_embulk004" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:08.425 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:08.425 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:08.427 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:08.622 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:08.622 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118e99d7_embulk005" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:08.623 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:08.623 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:08.625 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:08.728 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:08.728 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118e99d7_embulk006" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:08.729 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:08.729 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:08.731 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:08.847 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:08.848 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118e99d7_embulk007" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:08.897 +0000 [INFO] (0015:task-0000): Loading 2 rows
2024-03-06 02:19:09.172 +0000 [INFO] (0015:task-0000): > 0.28 seconds (loaded 2 rows in total)
2024-03-06 02:19:09.175 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-03-06 02:19:09.175 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:09.498 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:19:09.498 +0000 [INFO] (0001:transaction): SQL: DELETE FROM "test_schema"."test_table"
2024-03-06 02:19:10.421 +0000 [INFO] (0001:transaction): > 0.92 seconds (4 rows)
2024-03-06 02:19:10.421 +0000 [INFO] (0001:transaction): SQL: INSERT INTO "test_schema"."test_table" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118e99d7_embulk000" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118e99d7_embulk001" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118e99d7_embulk002" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118e99d7_embulk003" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118e99d7_embulk004" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118e99d7_embulk005" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118e99d7_embulk006" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118e99d7_embulk007"
2024-03-06 02:19:12.350 +0000 [INFO] (0001:transaction): > 1.93 seconds (2 rows)
2024-03-06 02:19:12.390 +0000 [WARN] (0001:transaction): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:12.390 +0000 [WARN] (0001:transaction): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:12.392 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:12.499 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:19:12.703 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118e99d7_embulk000"
2024-03-06 02:19:12.986 +0000 [INFO] (0001:transaction): > 0.28 seconds
2024-03-06 02:19:13.218 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118e99d7_embulk001"
2024-03-06 02:19:13.495 +0000 [INFO] (0001:transaction): > 0.28 seconds
2024-03-06 02:19:13.710 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118e99d7_embulk002"
2024-03-06 02:19:13.992 +0000 [INFO] (0001:transaction): > 0.28 seconds
2024-03-06 02:19:14.206 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118e99d7_embulk003"
2024-03-06 02:19:14.485 +0000 [INFO] (0001:transaction): > 0.28 seconds
2024-03-06 02:19:14.676 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118e99d7_embulk004"
2024-03-06 02:19:14.935 +0000 [INFO] (0001:transaction): > 0.26 seconds
2024-03-06 02:19:15.163 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118e99d7_embulk005"
2024-03-06 02:19:15.423 +0000 [INFO] (0001:transaction): > 0.26 seconds
2024-03-06 02:19:15.606 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118e99d7_embulk006"
2024-03-06 02:19:15.867 +0000 [INFO] (0001:transaction): > 0.26 seconds
2024-03-06 02:19:16.049 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118e99d7_embulk007"
2024-03-06 02:19:16.313 +0000 [INFO] (0001:transaction): > 0.26 seconds
2024-03-06 02:19:16.313 +0000 [INFO] (main): Committed.
2024-03-06 02:19:16.313 +0000 [INFO] (main): Next config diff: {"in":{"last_path":"test.jsonl"},"out":{}}
```

</details>
<details>
<summary>run (mode: update_insert)</summary>

```
$ embulk run config.yml
2024-03-06 02:19:47.125 +0000: Embulk v0.9.26
2024-03-06 02:19:47.722 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-03-06 02:19:49.047 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-03-06 02:19:49.583 +0000 [INFO] (main): Started Embulk v0.9.26
2024-03-06 02:19:49.654 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-sqlserver (0.10.5.trocco.0.0.1)
2024-03-06 02:19:49.689 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.1)
2024-03-06 02:19:49.699 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'test.jsonl'
2024-03-06 02:19:49.700 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2024-03-06 02:19:49.702 +0000 [INFO] (0001:transaction): Loading files [test.jsonl]
2024-03-06 02:19:49.721 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2024-03-06 02:19:49.742 +0000 [WARN] (0001:transaction): "UTC" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:49.753 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:50.271 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:19:50.271 +0000 [INFO] (0001:transaction): Using JDBC Driver 7.2.2.0
2024-03-06 02:19:50.271 +0000 [INFO] (0001:transaction): Using update_insert mode
2024-03-06 02:19:50.689 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118f580a_embulk000" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:51.402 +0000 [INFO] (0001:transaction): > 0.71 seconds
2024-03-06 02:19:51.447 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118f580a_embulk001" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:52.149 +0000 [INFO] (0001:transaction): > 0.70 seconds
2024-03-06 02:19:52.233 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118f580a_embulk002" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:53.051 +0000 [INFO] (0001:transaction): > 0.82 seconds
2024-03-06 02:19:53.136 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118f580a_embulk003" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:53.852 +0000 [INFO] (0001:transaction): > 0.72 seconds
2024-03-06 02:19:53.931 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118f580a_embulk004" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:54.659 +0000 [INFO] (0001:transaction): > 0.73 seconds
2024-03-06 02:19:54.731 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118f580a_embulk005" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:55.468 +0000 [INFO] (0001:transaction): > 0.74 seconds
2024-03-06 02:19:55.535 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118f580a_embulk006" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:56.253 +0000 [INFO] (0001:transaction): > 0.72 seconds
2024-03-06 02:19:56.328 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e118f580a_embulk007" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET)
2024-03-06 02:19:57.011 +0000 [INFO] (0001:transaction): > 0.68 seconds
2024-03-06 02:19:57.052 +0000 [INFO] (0001:transaction): Using merge keys: [test_string]
2024-03-06 02:19:57.068 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-03-06 02:19:57.080 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:57.080 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:57.090 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:57.206 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:57.207 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118f580a_embulk000" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:57.210 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:57.210 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:57.212 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:57.314 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:57.314 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118f580a_embulk001" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:57.315 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:57.315 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:57.317 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:57.419 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:57.419 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118f580a_embulk002" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:57.420 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:57.420 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:57.423 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:57.525 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:57.525 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118f580a_embulk003" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:57.526 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:57.526 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:57.528 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:57.639 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:57.639 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118f580a_embulk004" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:57.640 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:57.640 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:57.642 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:57.750 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:57.750 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118f580a_embulk005" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:57.751 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:57.751 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:57.753 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:57.851 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:57.852 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118f580a_embulk006" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:57.852 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:19:57.852 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:19:57.854 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:57.940 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:19:57.940 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e118f580a_embulk007" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:19:57.989 +0000 [INFO] (0015:task-0000): Loading 2 rows
2024-03-06 02:19:58.364 +0000 [INFO] (0015:task-0000): > 0.37 seconds (loaded 2 rows in total)
2024-03-06 02:19:58.367 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-03-06 02:19:58.368 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:19:58.550 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:19:58.551 +0000 [INFO] (0001:transaction): SQL: UPDATE T SET "test_boolean" = S."test_boolean", "test_long" = S."test_long", "test_double" = S."test_double", "test_string" = S."test_string", "test_timestamp" = S."test_timestamp" FROM "test_schema"."test_table" AS T JOIN (SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk000" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk001" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk002" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk003" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk004" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk005" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk006" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk007") AS S ON T."test_string" = S."test_string"
2024-03-06 02:20:03.267 +0000 [INFO] (0001:transaction): > 4.72 seconds (2 rows)
2024-03-06 02:20:03.267 +0000 [INFO] (0001:transaction): SQL: INSERT INTO "test_schema"."test_table" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") SELECT * FROM (SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk000" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk001" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk002" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk003" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk004" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk005" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk006" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e118f580a_embulk007") AS S WHERE NOT EXISTS (SELECT 1 FROM "test_schema"."test_table" AS T WHERE T."test_string" = S."test_string")
2024-03-06 02:20:05.547 +0000 [INFO] (0001:transaction): > 2.28 seconds
2024-03-06 02:20:05.625 +0000 [WARN] (0001:transaction): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:20:05.625 +0000 [WARN] (0001:transaction): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:20:05.627 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:20:05.751 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:20:05.915 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118f580a_embulk000"
2024-03-06 02:20:06.222 +0000 [INFO] (0001:transaction): > 0.31 seconds
2024-03-06 02:20:06.397 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118f580a_embulk001"
2024-03-06 02:20:06.711 +0000 [INFO] (0001:transaction): > 0.31 seconds
2024-03-06 02:20:06.865 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118f580a_embulk002"
2024-03-06 02:20:07.184 +0000 [INFO] (0001:transaction): > 0.32 seconds
2024-03-06 02:20:07.339 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118f580a_embulk003"
2024-03-06 02:20:07.617 +0000 [INFO] (0001:transaction): > 0.28 seconds
2024-03-06 02:20:07.776 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118f580a_embulk004"
2024-03-06 02:20:08.050 +0000 [INFO] (0001:transaction): > 0.27 seconds
2024-03-06 02:20:08.207 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118f580a_embulk005"
2024-03-06 02:20:08.486 +0000 [INFO] (0001:transaction): > 0.28 seconds
2024-03-06 02:20:08.654 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118f580a_embulk006"
2024-03-06 02:20:08.942 +0000 [INFO] (0001:transaction): > 0.29 seconds
2024-03-06 02:20:09.104 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e118f580a_embulk007"
2024-03-06 02:20:09.381 +0000 [INFO] (0001:transaction): > 0.28 seconds
2024-03-06 02:20:09.381 +0000 [INFO] (main): Committed.
2024-03-06 02:20:09.381 +0000 [INFO] (main): Next config diff: {"in":{"last_path":"test.jsonl"},"out":{}}
```

</details>
<details>
<summary>run (mode: replace)</summary>

```
$ embulk run config.yml
2024-03-06 02:22:34.120 +0000: Embulk v0.9.26
2024-03-06 02:22:34.715 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-03-06 02:22:35.959 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-03-06 02:22:36.423 +0000 [INFO] (main): Started Embulk v0.9.26
2024-03-06 02:22:36.512 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-sqlserver (0.10.5.trocco.0.0.1)
2024-03-06 02:22:36.554 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.1)
2024-03-06 02:22:36.564 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'test.jsonl'
2024-03-06 02:22:36.565 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2024-03-06 02:22:36.567 +0000 [INFO] (0001:transaction): Loading files [test.jsonl]
2024-03-06 02:22:36.586 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2024-03-06 02:22:36.608 +0000 [WARN] (0001:transaction): "UTC" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:22:36.619 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:22:37.024 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:22:37.024 +0000 [INFO] (0001:transaction): Using JDBC Driver 7.2.2.0
2024-03-06 02:22:37.024 +0000 [INFO] (0001:transaction): Using replace mode
2024-03-06 02:22:37.140 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e1191e23b_embulk" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET) WITH (DISTRIBUTION = HASH([test_string]))
2024-03-06 02:22:37.936 +0000 [INFO] (0001:transaction): > 0.80 seconds
2024-03-06 02:22:38.240 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-03-06 02:22:38.252 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:22:38.252 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:22:38.263 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:22:38.379 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:22:38.379 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e1191e23b_embulk" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:22:38.383 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:22:38.383 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:22:38.386 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:22:38.495 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:22:38.495 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e1191e23b_embulk" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:22:38.496 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:22:38.496 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:22:38.499 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:22:38.602 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:22:38.602 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e1191e23b_embulk" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:22:38.603 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:22:38.603 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:22:38.605 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:22:38.699 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:22:38.699 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e1191e23b_embulk" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:22:38.699 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:22:38.700 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:22:38.701 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:22:38.806 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:22:38.806 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e1191e23b_embulk" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:22:38.807 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:22:38.807 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:22:38.808 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:22:38.912 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:22:38.912 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e1191e23b_embulk" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:22:38.913 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:22:38.913 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:22:38.915 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:22:39.018 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:22:39.018 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e1191e23b_embulk" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:22:39.019 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:22:39.019 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:22:39.021 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:22:39.123 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:22:39.124 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e1191e23b_embulk" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:22:39.173 +0000 [INFO] (0015:task-0000): Loading 2 rows
2024-03-06 02:22:39.462 +0000 [INFO] (0015:task-0000): > 0.29 seconds (loaded 2 rows in total)
2024-03-06 02:22:39.465 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-03-06 02:22:39.465 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:22:39.573 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:22:39.689 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table"
2024-03-06 02:22:39.934 +0000 [INFO] (0001:transaction): > 0.24 seconds
2024-03-06 02:22:39.934 +0000 [INFO] (0001:transaction): SQL: RENAME OBJECT "test_schema"."test_table_0000018e1191e23b_embulk" TO "test_table"
2024-03-06 02:22:39.975 +0000 [INFO] (0001:transaction): > 0.04 seconds (-1 rows)
2024-03-06 02:22:39.992 +0000 [WARN] (0001:transaction): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:22:39.992 +0000 [WARN] (0001:transaction): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:22:39.994 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:22:40.094 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:22:40.190 +0000 [INFO] (main): Committed.
2024-03-06 02:22:40.190 +0000 [INFO] (main): Next config diff: {"in":{"last_path":"test.jsonl"},"out":{}}
```

</details>
<details>
<summary>run (mode: merge)</summary>

```
$ embulk run config.yml
2024-03-06 02:23:10.015 +0000: Embulk v0.9.26
2024-03-06 02:23:10.626 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-03-06 02:23:11.922 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-03-06 02:23:12.359 +0000 [INFO] (main): Started Embulk v0.9.26
2024-03-06 02:23:12.428 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-sqlserver (0.10.5.trocco.0.0.1)
2024-03-06 02:23:12.461 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.1)
2024-03-06 02:23:12.470 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'test.jsonl'
2024-03-06 02:23:12.471 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2024-03-06 02:23:12.474 +0000 [INFO] (0001:transaction): Loading files [test.jsonl]
2024-03-06 02:23:12.492 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2024-03-06 02:23:12.513 +0000 [WARN] (0001:transaction): "UTC" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:23:12.524 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:23:12.911 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:23:12.911 +0000 [INFO] (0001:transaction): Using JDBC Driver 7.2.2.0
2024-03-06 02:23:12.911 +0000 [INFO] (0001:transaction): Using merge mode
2024-03-06 02:23:13.166 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e11926ef5_embulk000" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET) WITH (DISTRIBUTION = HASH([test_string]))
2024-03-06 02:23:13.873 +0000 [INFO] (0001:transaction): > 0.71 seconds
2024-03-06 02:23:13.906 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e11926ef5_embulk001" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET) WITH (DISTRIBUTION = HASH([test_string]))
2024-03-06 02:23:14.596 +0000 [INFO] (0001:transaction): > 0.69 seconds
2024-03-06 02:23:14.632 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e11926ef5_embulk002" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET) WITH (DISTRIBUTION = HASH([test_string]))
2024-03-06 02:23:15.283 +0000 [INFO] (0001:transaction): > 0.65 seconds
2024-03-06 02:23:15.317 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e11926ef5_embulk003" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET) WITH (DISTRIBUTION = HASH([test_string]))
2024-03-06 02:23:16.053 +0000 [INFO] (0001:transaction): > 0.74 seconds
2024-03-06 02:23:16.089 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e11926ef5_embulk004" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET) WITH (DISTRIBUTION = HASH([test_string]))
2024-03-06 02:23:16.768 +0000 [INFO] (0001:transaction): > 0.68 seconds
2024-03-06 02:23:16.801 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e11926ef5_embulk005" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET) WITH (DISTRIBUTION = HASH([test_string]))
2024-03-06 02:23:17.494 +0000 [INFO] (0001:transaction): > 0.69 seconds
2024-03-06 02:23:17.528 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e11926ef5_embulk006" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET) WITH (DISTRIBUTION = HASH([test_string]))
2024-03-06 02:23:18.207 +0000 [INFO] (0001:transaction): > 0.68 seconds
2024-03-06 02:23:18.240 +0000 [INFO] (0001:transaction): SQL: CREATE TABLE "test_schema"."test_table_0000018e11926ef5_embulk007" ("test_boolean" BIT, "test_long" BIGINT, "test_double" FLOAT, "test_string" NVARCHAR(4000), "test_timestamp" DATETIMEOFFSET) WITH (DISTRIBUTION = HASH([test_string]))
2024-03-06 02:23:18.897 +0000 [INFO] (0001:transaction): > 0.66 seconds
2024-03-06 02:23:18.918 +0000 [INFO] (0001:transaction): Using merge keys: [test_string]
2024-03-06 02:23:18.932 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-03-06 02:23:18.944 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:23:18.944 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:23:18.954 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:23:19.059 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:23:19.059 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e11926ef5_embulk000" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:23:19.062 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:23:19.062 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:23:19.065 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:23:19.163 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:23:19.164 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e11926ef5_embulk001" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:23:19.165 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:23:19.165 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:23:19.167 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:23:19.269 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:23:19.269 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e11926ef5_embulk002" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:23:19.270 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:23:19.270 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:23:19.272 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:23:19.362 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:23:19.362 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e11926ef5_embulk003" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:23:19.363 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:23:19.363 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:23:19.365 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:23:19.460 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:23:19.460 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e11926ef5_embulk004" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:23:19.461 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:23:19.461 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:23:19.463 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:23:19.557 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:23:19.557 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e11926ef5_embulk005" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:23:19.558 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:23:19.558 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:23:19.560 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:23:19.656 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:23:19.657 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e11926ef5_embulk006" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:23:19.657 +0000 [WARN] (0015:task-0000): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:23:19.657 +0000 [WARN] (0015:task-0000): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:23:19.659 +0000 [INFO] (0015:task-0000): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:23:19.755 +0000 [INFO] (0015:task-0000): TransactionIsolation=read_committed
2024-03-06 02:23:19.755 +0000 [INFO] (0015:task-0000): Prepared SQL: INSERT INTO "test_schema"."test_table_0000018e11926ef5_embulk007" ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (?, ?, ?, ?, ?)
2024-03-06 02:23:19.804 +0000 [INFO] (0015:task-0000): Loading 2 rows
2024-03-06 02:23:20.089 +0000 [INFO] (0015:task-0000): > 0.28 seconds (loaded 2 rows in total)
2024-03-06 02:23:20.091 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-03-06 02:23:20.091 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:23:20.206 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:23:20.206 +0000 [INFO] (0001:transaction): SQL: MERGE INTO "test_schema"."test_table" AS T USING (SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e11926ef5_embulk000" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e11926ef5_embulk001" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e11926ef5_embulk002" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e11926ef5_embulk003" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e11926ef5_embulk004" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e11926ef5_embulk005" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e11926ef5_embulk006" UNION ALL SELECT "test_boolean", "test_long", "test_double", "test_string", "test_timestamp" FROM "test_schema"."test_table_0000018e11926ef5_embulk007") AS S ON (T."test_string" = S."test_string") WHEN MATCHED THEN UPDATE SET "test_boolean" = S."test_boolean", "test_long" = S."test_long", "test_double" = S."test_double", "test_string" = S."test_string", "test_timestamp" = S."test_timestamp" WHEN NOT MATCHED THEN INSERT ("test_boolean", "test_long", "test_double", "test_string", "test_timestamp") VALUES (S."test_boolean", S."test_long", S."test_double", S."test_string", S."test_timestamp");
2024-03-06 02:23:22.956 +0000 [INFO] (0001:transaction): > 2.75 seconds (4 rows)
2024-03-06 02:23:22.998 +0000 [WARN] (0001:transaction): Z is deprecated as a military time zone name. Use UTC instead.
2024-03-06 02:23:22.998 +0000 [WARN] (0001:transaction): "Z" is recognized as "Z" to be compatible with the legacy style.
2024-03-06 02:23:22.999 +0000 [INFO] (0001:transaction): Connecting to jdbc:sqlserver://test-synapse-workspace0.sql.azuresynapse.net:1433;databaseName=test_dedicated_sql_pool;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.sql.azuresynapse.net options {user=test_user@test-synapse-workspace0, password=***}
2024-03-06 02:23:23.099 +0000 [INFO] (0001:transaction): TransactionIsolation=read_committed
2024-03-06 02:23:23.206 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e11926ef5_embulk000"
2024-03-06 02:23:23.435 +0000 [INFO] (0001:transaction): > 0.23 seconds
2024-03-06 02:23:23.537 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e11926ef5_embulk001"
2024-03-06 02:23:23.766 +0000 [INFO] (0001:transaction): > 0.23 seconds
2024-03-06 02:23:23.854 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e11926ef5_embulk002"
2024-03-06 02:23:24.116 +0000 [INFO] (0001:transaction): > 0.26 seconds
2024-03-06 02:23:24.199 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e11926ef5_embulk003"
2024-03-06 02:23:24.416 +0000 [INFO] (0001:transaction): > 0.22 seconds
2024-03-06 02:23:24.497 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e11926ef5_embulk004"
2024-03-06 02:23:24.723 +0000 [INFO] (0001:transaction): > 0.23 seconds
2024-03-06 02:23:24.812 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e11926ef5_embulk005"
2024-03-06 02:23:25.023 +0000 [INFO] (0001:transaction): > 0.21 seconds
2024-03-06 02:23:25.111 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e11926ef5_embulk006"
2024-03-06 02:23:25.344 +0000 [INFO] (0001:transaction): > 0.23 seconds
2024-03-06 02:23:25.435 +0000 [INFO] (0001:transaction): SQL: DROP TABLE "test_schema"."test_table_0000018e11926ef5_embulk007"
2024-03-06 02:23:25.664 +0000 [INFO] (0001:transaction): > 0.23 seconds
2024-03-06 02:23:25.665 +0000 [INFO] (main): Committed.
2024-03-06 02:23:25.665 +0000 [INFO] (main): Next config diff: {"in":{"last_path":"test.jsonl"},"out":{}}
```

</details>