### PR TITLE
Add keepalive to prevent MySQL connection timeout during long input processing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           _JAVA_OPTIONS: "-Xmx2048m -Xms512m"
           EMBULK_OUTPUT_MYSQL_TEST_CONFIG: "${{ github.workspace }}/ci/mysql.yml"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: mysql
@@ -76,7 +76,7 @@ jobs:
         env:
           _JAVA_OPTIONS: "-Xmx2048m -Xms512m"
           EMBULK_OUTPUT_POSTGRESQL_TEST_CONFIG: "${{ github.workspace }}/ci/postgresql.yml"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: postgresql
@@ -118,7 +118,7 @@ jobs:
         env:
           _JAVA_OPTIONS: "-Xmx2048m -Xms512m"
           EMBULK_OUTPUT_REDSHIFT_TEST_CONFIG: "${{ github.workspace }}/ci/redshift.yml"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: redshift

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ allprojects {
 }
 
 ext {
-    troccoVersion = "0.0.2"
+    troccoVersion = "0.0.3"
 }
 
 subprojects {
@@ -77,6 +77,7 @@ subprojects {
         testImplementation "org.embulk:embulk-junit4:0.10.49"
         testImplementation "org.embulk:embulk-core:0.10.49"
         testImplementation "org.embulk:embulk-deps:0.10.49"
+        testImplementation "org.mockito:mockito-core:4.11.0"
     }
 
     test {

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/JdbcOutputConnection.java
@@ -729,4 +729,14 @@ public class JdbcOutputConnection
         logger.info(String.format(Locale.ENGLISH,"Using JDBC Driver %s",meta.getDriverVersion()));
     }
 
+    /**
+     * Returns the underlying JDBC Connection.
+     * This is used by KeepAliveManager to execute keep-alive queries.
+     *
+     * @return The underlying JDBC Connection
+     */
+    public Connection getConnection() {
+        return connection;
+    }
+
 }

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/KeepAliveManager.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/KeepAliveManager.java
@@ -1,0 +1,175 @@
+package org.embulk.output.jdbc;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages the lifecycle of a keep-alive task that periodically executes a simple query
+ * (e.g., "SELECT 1") to prevent the database connection from being closed due to idle timeout.
+ *
+ * <p>This is particularly useful when the output connection is established before input processing,
+ * and the input processing takes a long time (e.g., fetching data from external APIs).
+ * Without keep-alive, intermediate network devices (like AWS Gateway with ~350 second timeout)
+ * may terminate idle connections.
+ *
+ * <p>Thread Safety:
+ * This class provides pause() and resume() methods to safely suspend keep-alive queries
+ * during batch operations, preventing any concurrent access to the JDBC connection.
+ *
+ * <p>Usage:
+ * <pre>
+ * KeepAliveManager keepAlive = KeepAliveManager.start(connection, 30000L);
+ * try {
+ *     // ... long running operation ...
+ *
+ *     // Before batch execution:
+ *     keepAlive.pause();  // Waits for any in-progress query to complete
+ *     try {
+ *         batch.executeBatch();
+ *     } finally {
+ *         keepAlive.resume();
+ *     }
+ * } finally {
+ *     keepAlive.stop();
+ * }
+ * </pre>
+ */
+public class KeepAliveManager {
+    private static final Logger logger = LoggerFactory.getLogger(KeepAliveManager.class);
+    private static final String KEEP_ALIVE_QUERY = "SELECT 1";
+    private static final long DEFAULT_INTERVAL_MILLIS = 30000L; // 30 seconds
+
+    private final ExecutorService executor;
+    private final Future<?> task;
+    private final AtomicBoolean stopped;
+    private final AtomicBoolean paused;
+    private final ReentrantLock queryLock;
+
+    private KeepAliveManager(ExecutorService executor, Future<?> task, AtomicBoolean stopped,
+                             AtomicBoolean paused, ReentrantLock queryLock) {
+        this.executor = executor;
+        this.task = task;
+        this.stopped = stopped;
+        this.paused = paused;
+        this.queryLock = queryLock;
+    }
+
+    /**
+     * Starts a background keep-alive task with the default interval (30 seconds).
+     *
+     * @param connection The JDBC connection to keep alive
+     * @return A KeepAliveManager instance to control the keep-alive task
+     */
+    public static KeepAliveManager start(Connection connection) {
+        return start(connection, DEFAULT_INTERVAL_MILLIS);
+    }
+
+    /**
+     * Starts a background keep-alive task that periodically executes a lightweight query
+     * to keep the database connection active.
+     *
+     * @param connection The JDBC connection to keep alive
+     * @param intervalMillis The interval in milliseconds between each keep-alive query execution
+     * @return A KeepAliveManager instance to control the keep-alive task
+     */
+    public static KeepAliveManager start(Connection connection, long intervalMillis) {
+        AtomicBoolean stopped = new AtomicBoolean(false);
+        AtomicBoolean paused = new AtomicBoolean(false);
+        ReentrantLock queryLock = new ReentrantLock();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "jdbc-output-keepalive");
+            t.setDaemon(true);
+            return t;
+        });
+
+        Future<?> task = executor.submit(() -> {
+            logger.info("Keep-alive task started (interval: {}ms)", intervalMillis);
+            try {
+                while (!Thread.currentThread().isInterrupted() && !stopped.get()) {
+                    Thread.sleep(intervalMillis);
+                    if (stopped.get()) {
+                        break;
+                    }
+                    // Skip if paused, but don't block
+                    if (paused.get()) {
+                        continue;
+                    }
+                    // Acquire lock before executing query to ensure thread safety
+                    queryLock.lock();
+                    try {
+                        // Double-check after acquiring lock
+                        if (stopped.get() || paused.get()) {
+                            continue;
+                        }
+                        try (Statement stmt = connection.createStatement()) {
+                            stmt.executeQuery(KEEP_ALIVE_QUERY);
+                            logger.debug("Executed keep-alive query: {}", KEEP_ALIVE_QUERY);
+                        } catch (SQLException e) {
+                            if (!stopped.get()) {
+                                logger.warn("Keep-alive query failed: {}", e.getMessage());
+                            }
+                        }
+                    } finally {
+                        queryLock.unlock();
+                    }
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.debug("Keep-alive task interrupted");
+            }
+            logger.info("Keep-alive task stopped");
+        });
+
+        return new KeepAliveManager(executor, task, stopped, paused, queryLock);
+    }
+
+    /**
+     * Pauses the keep-alive task. This method blocks until any in-progress keep-alive query
+     * completes, ensuring no concurrent access to the connection after this method returns.
+     *
+     * <p>Call this method before executing batch operations to prevent concurrent connection access.
+     * Always call {@link #resume()} after the batch operation completes.
+     *
+     * <p>This method is idempotent and can be called multiple times safely.
+     */
+    public void pause() {
+        paused.set(true);
+        // Acquire and immediately release the lock to wait for any in-progress query to complete
+        queryLock.lock();
+        queryLock.unlock();
+        logger.debug("Keep-alive paused");
+    }
+
+    /**
+     * Resumes the keep-alive task after it was paused.
+     *
+     * <p>This method is idempotent and can be called multiple times safely.
+     */
+    public void resume() {
+        paused.set(false);
+        logger.debug("Keep-alive resumed");
+    }
+
+    /**
+     * Stops the keep-alive task permanently by cancelling the running thread and
+     * shutting down the executor.
+     *
+     * <p>This method is idempotent and can be called multiple times safely.
+     */
+    public void stop() {
+        stopped.set(true);
+        paused.set(true);  // Also set paused to prevent any new queries
+        task.cancel(true);
+        executor.shutdownNow();
+        logger.debug("Keep-alive stopped");
+    }
+}

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/KeepAliveManager.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/KeepAliveManager.java
@@ -112,7 +112,6 @@ public class KeepAliveManager {
                         }
                         try (Statement stmt = connection.createStatement()) {
                             stmt.executeQuery(KEEP_ALIVE_QUERY);
-                            logger.debug("Executed keep-alive query: {}", KEEP_ALIVE_QUERY);
                         } catch (SQLException e) {
                             if (!stopped.get()) {
                                 logger.warn("Keep-alive query failed: {}", e.getMessage());
@@ -124,7 +123,6 @@ public class KeepAliveManager {
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                logger.debug("Keep-alive task interrupted");
             }
             logger.info("Keep-alive task stopped");
         });
@@ -146,7 +144,6 @@ public class KeepAliveManager {
         // Acquire and immediately release the lock to wait for any in-progress query to complete
         queryLock.lock();
         queryLock.unlock();
-        logger.debug("Keep-alive paused");
     }
 
     /**
@@ -156,7 +153,6 @@ public class KeepAliveManager {
      */
     public void resume() {
         paused.set(false);
-        logger.debug("Keep-alive resumed");
     }
 
     /**
@@ -170,6 +166,5 @@ public class KeepAliveManager {
         paused.set(true);  // Also set paused to prevent any new queries
         task.cancel(true);
         executor.shutdownNow();
-        logger.debug("Keep-alive stopped");
     }
 }

--- a/embulk-output-jdbc/src/test/java/org/embulk/output/jdbc/KeepAliveManagerTest.java
+++ b/embulk-output-jdbc/src/test/java/org/embulk/output/jdbc/KeepAliveManagerTest.java
@@ -1,0 +1,312 @@
+package org.embulk.output.jdbc;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for KeepAliveManager.
+ *
+ * These tests verify that:
+ * 1. KeepAliveManager starts and executes keep-alive queries
+ * 2. KeepAliveManager stops properly when stop() is called
+ * 3. KeepAliveManager handles connection errors gracefully
+ * 4. pause() blocks until in-progress queries complete
+ * 5. resume() allows queries to continue
+ */
+public class KeepAliveManagerTest {
+
+    private Connection mockConnection;
+    private Statement mockStatement;
+    private ResultSet mockResultSet;
+
+    @Before
+    public void setUp() throws SQLException {
+        mockConnection = mock(Connection.class);
+        mockStatement = mock(Statement.class);
+        mockResultSet = mock(ResultSet.class);
+
+        when(mockConnection.createStatement()).thenReturn(mockStatement);
+        when(mockStatement.executeQuery("SELECT 1")).thenReturn(mockResultSet);
+    }
+
+    @After
+    public void tearDown() throws SQLException {
+        // Clean up mocks
+        reset(mockConnection, mockStatement, mockResultSet);
+    }
+
+    @Test
+    public void testStartAndStop() throws Exception {
+        // Start keep-alive with a short interval for testing
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection, 100L);
+
+        assertNotNull("KeepAliveManager should be created", manager);
+
+        // Wait for at least one keep-alive query to be executed
+        Thread.sleep(250);
+
+        // Stop the manager
+        manager.stop();
+
+        // Verify that at least one keep-alive query was executed
+        verify(mockConnection, atLeastOnce()).createStatement();
+        verify(mockStatement, atLeastOnce()).executeQuery("SELECT 1");
+    }
+
+    @Test
+    public void testStopPreventsMoreQueries() throws Exception {
+        AtomicInteger queryCount = new AtomicInteger(0);
+
+        // Create a mock that counts queries
+        when(mockStatement.executeQuery("SELECT 1")).thenAnswer(invocation -> {
+            queryCount.incrementAndGet();
+            return mockResultSet;
+        });
+
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection, 50L);
+
+        // Wait for some queries to execute
+        Thread.sleep(150);
+
+        // Stop the manager
+        manager.stop();
+
+        int countAfterStop = queryCount.get();
+
+        // Wait a bit more
+        Thread.sleep(150);
+
+        // Count should not have increased significantly after stop
+        int countAfterWait = queryCount.get();
+
+        // The count should be the same or at most 1 more (if a query was in flight)
+        assertTrue("Queries should stop after stop() is called",
+                countAfterWait <= countAfterStop + 1);
+    }
+
+    @Test
+    public void testHandlesSQLException() throws Exception {
+        // Simulate a SQL exception on the first query, success on subsequent queries
+        AtomicInteger callCount = new AtomicInteger(0);
+        when(mockStatement.executeQuery("SELECT 1")).thenAnswer(invocation -> {
+            if (callCount.incrementAndGet() == 1) {
+                throw new SQLException("Connection lost");
+            }
+            return mockResultSet;
+        });
+
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection, 50L);
+
+        // Wait for multiple query attempts
+        Thread.sleep(200);
+
+        // Stop the manager - should not throw
+        manager.stop();
+
+        // Verify that multiple queries were attempted despite the exception
+        verify(mockStatement, atLeast(2)).executeQuery("SELECT 1");
+    }
+
+    @Test
+    public void testDefaultInterval() throws Exception {
+        // Test that default interval is used (30 seconds)
+        // We just verify that start() without interval works
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection);
+
+        assertNotNull("KeepAliveManager should be created with default interval", manager);
+
+        // Immediately stop - we don't want to wait 30 seconds in a test
+        manager.stop();
+    }
+
+    @Test
+    public void testMultipleStopCalls() throws Exception {
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection, 100L);
+
+        // Stop multiple times should not throw
+        manager.stop();
+        manager.stop();
+        manager.stop();
+
+        // If we get here without exception, the test passes
+    }
+
+    @Test
+    public void testClosedStatementAfterQuery() throws Exception {
+        // Verify that Statement is closed after each query (try-with-resources behavior)
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection, 100L);
+
+        Thread.sleep(250);
+
+        manager.stop();
+
+        // Statement.close() should have been called
+        verify(mockStatement, atLeastOnce()).close();
+    }
+
+    @Test
+    public void testPausePreventsQueries() throws Exception {
+        AtomicInteger queryCount = new AtomicInteger(0);
+
+        when(mockStatement.executeQuery("SELECT 1")).thenAnswer(invocation -> {
+            queryCount.incrementAndGet();
+            return mockResultSet;
+        });
+
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection, 50L);
+
+        // Wait for at least one query
+        Thread.sleep(100);
+
+        // Pause the manager
+        manager.pause();
+        int countAfterPause = queryCount.get();
+
+        // Wait while paused
+        Thread.sleep(150);
+
+        // Count should not have increased while paused
+        int countWhilePaused = queryCount.get();
+        assertEquals("No queries should execute while paused", countAfterPause, countWhilePaused);
+
+        manager.stop();
+    }
+
+    @Test
+    public void testResumeAllowsQueries() throws Exception {
+        AtomicInteger queryCount = new AtomicInteger(0);
+
+        when(mockStatement.executeQuery("SELECT 1")).thenAnswer(invocation -> {
+            queryCount.incrementAndGet();
+            return mockResultSet;
+        });
+
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection, 50L);
+
+        // Wait for at least one query
+        Thread.sleep(100);
+
+        // Pause
+        manager.pause();
+        int countAfterPause = queryCount.get();
+
+        // Wait while paused
+        Thread.sleep(100);
+
+        // Resume
+        manager.resume();
+
+        // Wait for more queries after resume
+        Thread.sleep(150);
+
+        int countAfterResume = queryCount.get();
+
+        // Queries should have resumed
+        assertTrue("Queries should resume after resume() is called",
+                countAfterResume > countAfterPause);
+
+        manager.stop();
+    }
+
+    @Test
+    public void testPauseWaitsForInProgressQuery() throws Exception {
+        CountDownLatch queryStarted = new CountDownLatch(1);
+        CountDownLatch queryCanComplete = new CountDownLatch(1);
+        AtomicBoolean queryCompleted = new AtomicBoolean(false);
+
+        // Create a mock that blocks during query execution
+        when(mockStatement.executeQuery("SELECT 1")).thenAnswer(invocation -> {
+            queryStarted.countDown();
+            // Wait until we're told to complete
+            queryCanComplete.await(5, TimeUnit.SECONDS);
+            queryCompleted.set(true);
+            return mockResultSet;
+        });
+
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection, 50L);
+
+        // Wait for query to start
+        boolean started = queryStarted.await(1, TimeUnit.SECONDS);
+        assertTrue("Query should have started", started);
+
+        // Start pause in a separate thread (it should block)
+        AtomicBoolean pauseCompleted = new AtomicBoolean(false);
+        Thread pauseThread = new Thread(() -> {
+            manager.pause();
+            pauseCompleted.set(true);
+        });
+        pauseThread.start();
+
+        // Give pause thread time to start
+        Thread.sleep(50);
+
+        // pause() should not have completed yet (query is still running)
+        assertFalse("pause() should block while query is in progress", pauseCompleted.get());
+
+        // Allow the query to complete
+        queryCanComplete.countDown();
+
+        // Wait for pause to complete
+        pauseThread.join(1000);
+
+        // Now pause should be completed
+        assertTrue("pause() should complete after query finishes", pauseCompleted.get());
+        assertTrue("Query should have completed", queryCompleted.get());
+
+        manager.stop();
+    }
+
+    @Test
+    public void testMultiplePauseCalls() throws Exception {
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection, 100L);
+
+        // Multiple pause calls should not throw
+        manager.pause();
+        manager.pause();
+        manager.pause();
+
+        manager.stop();
+    }
+
+    @Test
+    public void testMultipleResumeCalls() throws Exception {
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection, 100L);
+
+        manager.pause();
+
+        // Multiple resume calls should not throw
+        manager.resume();
+        manager.resume();
+        manager.resume();
+
+        manager.stop();
+    }
+
+    @Test
+    public void testPauseResumeDoesNotAffectStop() throws Exception {
+        KeepAliveManager manager = KeepAliveManager.start(mockConnection, 100L);
+
+        manager.pause();
+        manager.resume();
+        manager.stop();
+
+        // After stop, pause and resume should be safe to call
+        manager.pause();
+        manager.resume();
+
+        // If we get here without exception, the test passes
+    }
+}


### PR DESCRIPTION
# PR #10: Add Keepalive for MySQL Output Connection

## Overview

This PR adds a keep-alive mechanism to the embulk-output-jdbc plugin to prevent MySQL connection timeouts during long-running input processing.

## Problem

When the output connection is established before input processing begins, and the input takes a long time (e.g., fetching data from external APIs), intermediate network devices such as AWS Gateway (with ~350 second timeout) may terminate idle connections. This causes job failures due to connection loss.

## Solution

Introduces a `KeepAliveManager` class that periodically executes lightweight queries (`SELECT 1`) in a background thread to keep the database connection active.

### Key Features

- **Background Thread Execution**: Runs keep-alive queries in a daemon thread at configurable intervals (default: 30 seconds)
- **Thread-Safe Design**: Uses `ReentrantLock` and atomic flags to ensure safe concurrent access
- **Pause/Resume Support**: Provides `pause()` and `resume()` methods to safely suspend keep-alive during batch operations, preventing concurrent connection access
- **Graceful Error Handling**: Logs warnings on query failures without crashing the main process

## Reference

- Related Issue: https://github.com/primenumber-dev/n-transfer-ui/issues/40204
