### PR TITLE
feat: add option to disable MemoryRecord saving in PageReaderRecord

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -1157,7 +1157,14 @@ public abstract class AbstractJdbcOutputPlugin
                 BatchInsert batch, List<ColumnSetter> columnSetters,
                 int batchSize, PluginTask task)
         {
-            this.pageReader = new PageReaderRecord(pageReader);
+            this(pageReader, batch, columnSetters, batchSize, task, true);
+        }
+
+        public PluginPageOutput(PageReader pageReader,
+                BatchInsert batch, List<ColumnSetter> columnSetters,
+                int batchSize, PluginTask task, boolean saveRecordsForRetry)
+        {
+            this.pageReader = new PageReaderRecord(pageReader, saveRecordsForRetry);
             this.batch = batch;
             this.columns = pageReader.getSchema().getColumns();
             this.columnSetters = columnSetters;

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -1100,7 +1100,7 @@ public abstract class AbstractJdbcOutputPlugin
             }
             batch.prepare(destTable, insertIntoSchema);
 
-            PluginPageOutput output = new PluginPageOutput(reader, batch, columnSetters, task.getBatchSize(), task);
+            PluginPageOutput output = new PluginPageOutput(reader, batch, columnSetters, task.getBatchSize(), task, saveRecordsForRetry());
             batch = null;
             return output;
 
@@ -1116,6 +1116,16 @@ public abstract class AbstractJdbcOutputPlugin
                 }
             }
         }
+    }
+
+    /**
+     * Whether to save records in memory for row-level retry.
+     * Subclasses that use file-based batch insert (e.g. COPY) can override
+     * this to return {@code false} to avoid unnecessary heap pressure.
+     */
+    protected boolean saveRecordsForRetry()
+    {
+        return true;
     }
 
     public static File findPluginRoot(Class<?> cls)

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/PageReaderRecord.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/PageReaderRecord.java
@@ -2,6 +2,7 @@ package org.embulk.output.jdbc;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.embulk.spi.Column;
@@ -12,17 +13,28 @@ import org.msgpack.value.Value;
 /**
  * Record read by PageReader.
  * The class will save read records for retry.
+ *
+ * When {@code saveRecords} is {@code false}, records are not saved to memory,
+ * which avoids heap pressure for batch-insert implementations that do not
+ * need row-level retry (e.g. file-based COPY).
  */
 public class PageReaderRecord implements Record
 {
     private final PageReader pageReader;
     private final List<MemoryRecord> readRecords;
+    private final boolean saveRecords;
     private MemoryRecord lastRecord;
 
     public PageReaderRecord(PageReader pageReader)
     {
+        this(pageReader, true);
+    }
+
+    public PageReaderRecord(PageReader pageReader, boolean saveRecords)
+    {
         this.pageReader = pageReader;
-        readRecords = new ArrayList<>();
+        this.saveRecords = saveRecords;
+        readRecords = saveRecords ? new ArrayList<>() : Collections.<MemoryRecord>emptyList();
     }
 
     public void setPage(Page page)
@@ -84,6 +96,9 @@ public class PageReaderRecord implements Record
 
     private <T> T save(Column column, T value)
     {
+        if (!saveRecords) {
+            return value;
+        }
         if (lastRecord == null) {
             lastRecord = new MemoryRecord(pageReader.getSchema().getColumnCount());
             readRecords.add(lastRecord);


### PR DESCRIPTION
## Summary

- Add a `saveRecords` flag to `PageReaderRecord`. When set to `false`, `save()` skips copying values to `MemoryRecord` and returns them directly
- Add a `saveRecordsForRetry` parameter to the `PluginPageOutput` constructor, allowing subclass plugins to control whether records are accumulated
- Add an overridable `saveRecordsForRetry()` method to `AbstractJdbcOutputPlugin`, so subclasses can disable record saving by simply overriding this method
- Existing constructors default to `saveRecords=true` (backward compatible)

## Background

File-based BatchInsert implementations (Snowflake PUT+COPY, Redshift S3+COPY, PostgreSQL COPY) do not use row-level retry (`retryColumnsSetters()`), so accumulating `MemoryRecord` copies between flushes is unnecessary.

In memory-constrained environments (production: 2GB), this accumulation causes `MemoryRecord` objects to be promoted to Old Gen, where CMS GC cannot keep up, resulting in `GC overhead limit exceeded` OOM errors.

With this change, subclass plugins (e.g. embulk-output-snowflake) can simply override `saveRecordsForRetry()` to return `false`:

```java
@Override
protected boolean saveRecordsForRetry() {
    return false;
}
```

## Test plan

- [ ] Verify existing tests pass (backward compatibility)
- [ ] Call from Snowflake plugin with `saveRecordsForRetry()` returning `false`, and confirm no OOM occurs under memory-limited environment (768MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)