### PR TITLE
Restrict check.yml to branch pushes only

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,8 @@
 name: Check
-on: [ push ]
+on:
+  push:
+    branches:
+      - '**'
 jobs:
   mysql5_7:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

- Tag pushでPublishとCheckが独立で走ってしまい、事後的にしかCheckの失敗がわからず意味がない
- そもそもPull Requestの時点で全Checkが走るのであればTag pushでは発火しなくてよいかなと考えました

## Summary

- Change `check.yml` trigger from `on: [push]` to `on: push: branches: '**'` to exclude tag pushes
- DB integration tests were running unnecessarily on every tag push, which is already handled by `release.yml`

## Test plan

- [ ] Confirm `check.yml` does not trigger on tag push
- [ ] Confirm `check.yml` still triggers on branch push

🤖 Generated with [Claude Code](https://claude.com/claude-code)